### PR TITLE
IL2CPPでAndroidビルドする時の問題を修正

### DIFF
--- a/Assets/UniVersionManager/UniVersionManager.cs
+++ b/Assets/UniVersionManager/UniVersionManager.cs
@@ -8,10 +8,12 @@ using UnityEditor;
 public static class UniVersionManager
 {
 
+#if UNITY_IOS
     [DllImport("__Internal")]
     private static extern string GetVersionName_();
     [DllImport("__Internal")]
     private static extern string GetBuildVersionName_ ();
+#endif
 
     public static string GetVersion ()
     {


### PR DESCRIPTION
IL2CPPでAndroidビルドするとエラーが現れてビルド失敗する現象を確認しました。`DllImport` の部分をiOS限定にするとビルドできる様になりました。

環境: Unity v2018.2.13f1, .NET 4.x

Stack trace:
```
D:/Project/Library/il2cpp_android_armeabi-v7a/il2cpp_cache/0CB687838D0A09F6B52D684FFAD5EC74.o: In function `UniVersionManager_GetVersionName__m2803709039':
D:\Project\Alpha\Temp\StagingArea\Il2Cpp\il2cppOutput/Bulk_Assembly-CSharp-firstpass_11.cpp:27301: undefined reference to `GetVersionName_'
D:/Project/Alpha/Library/il2cpp_android_armeabi-v7a/il2cpp_cache/0CB687838D0A09F6B52D684FFAD5EC74.o: In function `UniVersionManager_GetBuildVersionName__m935022371':
D:\Project\Alpha\Temp\StagingArea\Il2Cpp\il2cppOutput/Bulk_Assembly-CSharp-firstpass_11.cpp:27320: undefined reference to `GetBuildVersionName_'
clang++.exe: error: linker command failed with exit code 1 (use -v to see invocation)
```